### PR TITLE
markdown: add Renderer interface

### DIFF
--- a/html.v
+++ b/html.v
@@ -1,8 +1,8 @@
 /*
- * MD4C: Markdown parser for C
+* MD4C: Markdown parser for C
  * (http://github.com/mity/md4c)
  *
- * Copyright (c) 2016-2019 Martin Mitáš 
+ * Copyright (c) 2016-2019 Martin Mitáš
  * Copyright (c) 2020 Ned Palacios (V bindings)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
@@ -22,26 +22,26 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
- */
+*/
 
 module markdown
 
 import strings
 
-fn C.md_html(orig_input charptr, orig_input_size u32, process_output ProcessFn, userdata voidptr, parser_flags u32, renderer_flags u32) int
+fn C.md_html(orig_input &char, orig_input_size u32, process_output ProcessFn, userdata voidptr, parser_flags u32, renderer_flags u32) int
 
 const (
-	need_html_esc_flag = 0x1
-	need_url_esc_flag  = 0x2
-	md_html_flag_debug = 0x0001
+	need_html_esc_flag             = 0x1
+	need_url_esc_flag              = 0x2
+	md_html_flag_debug             = 0x0001
 	md_html_flag_verbatim_entities = 0x0002
-	md_html_flag_skip_utf8_bom = 0x0004
+	md_html_flag_skip_utf8_bom     = 0x0004
 )
 
-type ProcessFn = fn (t charptr, s u32, x voidptr)
+type ProcessFn = fn (t &char, s u32, x voidptr)
 
-fn write_data_cb(txt charptr, size u32, mut sb strings.Builder) {
-	s := unsafe { tos(byteptr(txt), int(size)) }
+fn write_data_cb(txt &char, size u32, mut sb strings.Builder) {
+	s := unsafe { tos(&byte(txt), int(size)) }
 	sb.write_string(s)
 }
 

--- a/markdown_test.v
+++ b/markdown_test.v
@@ -1,8 +1,8 @@
 /*
- * MD4C: Markdown parser for C
+* MD4C: Markdown parser for C
  * (http://github.com/mity/md4c)
  *
- * Copyright (c) 2016-2019 Martin Mitáš 
+ * Copyright (c) 2016-2019 Martin Mitáš
  * Copyright (c) 2020 Ned Palacios (V bindings)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
@@ -22,7 +22,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
- */
+*/
 
 module markdown
 

--- a/md4c.v
+++ b/md4c.v
@@ -1,8 +1,8 @@
 /*
- * MD4C: Markdown parser for C
+* MD4C: Markdown parser for C
  * (http://github.com/mity/md4c)
  *
- * Copyright (c) 2016-2019 Martin Mitáš 
+ * Copyright (c) 2016-2019 Martin Mitáš
  * Copyright (c) 2020 Ned Palacios (V bindings)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
@@ -22,7 +22,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
- */
+*/
 module markdown
 
 #flag -I @VROOT/lib/md4c
@@ -31,9 +31,12 @@ module markdown
 #include "md4c-html.h"
 
 type BlockFn = fn (t MD_BLOCKTYPE, d voidptr, u voidptr) int
+
 type SpanFn = fn (t MD_SPANTYPE, d voidptr, u voidptr) int
-type TextFn = fn (t MD_TEXTTYPE, tx charptr, s u32, u voidptr) int
-type DebugFn = fn (m charptr, u voidptr)
+
+type TextFn = fn (t MD_TEXTTYPE, tx &char, s u32, u voidptr) int
+
+type DebugFn = fn (m &char, u voidptr)
 
 pub enum MD_BLOCKTYPE {
 	md_block_doc = 0
@@ -88,40 +91,40 @@ pub enum MD_ALIGN {
 pub struct C.MD_PARSER {
 pub:
 	abi_version u32
-	flags u32
+	flags       u32
 	enter_block BlockFn
 	leave_block BlockFn
-	enter_span SpanFn
-	leave_span SpanFn
-	text TextFn
-	debug_log DebugFn
+	enter_span  SpanFn
+	leave_span  SpanFn
+	text        TextFn
+	debug_log   DebugFn
 }
 
 pub struct C.MD_ATTRIBUTE {
 pub:
-	text charptr
-	size u32
-	substr_types MD_TEXTTYPE
+	text           &char
+	size           u32
+	substr_types   MD_TEXTTYPE
 	substr_offsets u32
 }
 
 pub struct C.MD_BLOCK_UL_DETAIL {
 pub:
 	is_tight int
-	mark byte
+	mark     byte
 }
 
 pub struct C.MD_BLOCK_OL_DETAIL {
 pub:
-	start u32
-	is_tight int
+	start          u32
+	is_tight       int
 	mark_delimiter byte
 }
 
 pub struct C.MD_BLOCK_LI_DETAIL {
 pub:
-	is_task int
-	task_mark byte
+	is_task          int
+	task_mark        byte
 	task_mark_offset u32
 }
 
@@ -132,8 +135,8 @@ pub:
 
 pub struct C.MD_BLOCK_CODE_DETAIL {
 pub:
-	info C.MD_ATTRIBUTE
-	lang C.MD_ATTRIBUTE
+	info       C.MD_ATTRIBUTE
+	lang       C.MD_ATTRIBUTE
 	fence_char byte
 }
 
@@ -144,13 +147,13 @@ pub:
 
 pub struct C.MD_SPAN_A_DETAIL {
 pub:
-	href C.MD_ATTRIBUTE
+	href  C.MD_ATTRIBUTE
 	title C.MD_ATTRIBUTE
 }
 
 pub struct C.MD_SPAN_IMG_DETAIL {
 pub:
-	src C.MD_ATTRIBUTE
+	src   C.MD_ATTRIBUTE
 	title C.MD_ATTRIBUTE
 }
 
@@ -159,7 +162,7 @@ pub:
 	target C.MD_ATTRIBUTE
 }
 
-pub fn C.md_parse(text charptr, size u32, parser &C.MD_PARSER, userdata voidptr) int
+pub fn C.md_parse(text &char, size u32, parser &C.MD_PARSER, userdata voidptr) int
 
 pub fn new(parser_flags u32, enter_block_cb BlockFn, leave_block_cb BlockFn, enter_span_cb SpanFn, leave_span_cb SpanFn, text_cb TextFn, debug_cb DebugFn) C.MD_PARSER {
 	return C.MD_PARSER{
@@ -174,6 +177,6 @@ pub fn new(parser_flags u32, enter_block_cb BlockFn, leave_block_cb BlockFn, ent
 	}
 }
 
-pub fn parse(text charptr, size u32, parser &C.MD_PARSER, userdata voidptr) int {
+pub fn parse(text &char, size u32, parser &C.MD_PARSER, userdata voidptr) int {
 	return C.md_parse(text, size, parser, userdata)
 }

--- a/md4c.v
+++ b/md4c.v
@@ -88,6 +88,7 @@ pub enum MD_ALIGN {
 	md_align_right
 }
 
+[typedef]
 pub struct C.MD_PARSER {
 pub:
 	abi_version u32
@@ -100,6 +101,7 @@ pub:
 	debug_log   DebugFn
 }
 
+[typedef]
 pub struct C.MD_ATTRIBUTE {
 pub:
 	text           &char
@@ -108,12 +110,14 @@ pub:
 	substr_offsets u32
 }
 
+[typedef]
 pub struct C.MD_BLOCK_UL_DETAIL {
 pub:
 	is_tight int
 	mark     byte
 }
 
+[typedef]
 pub struct C.MD_BLOCK_OL_DETAIL {
 pub:
 	start          u32
@@ -121,6 +125,7 @@ pub:
 	mark_delimiter byte
 }
 
+[typedef]
 pub struct C.MD_BLOCK_LI_DETAIL {
 pub:
 	is_task          int
@@ -128,11 +133,13 @@ pub:
 	task_mark_offset u32
 }
 
+[typedef]
 pub struct C.MD_BLOCK_H_DETAIL {
 pub:
 	level u32
 }
 
+[typedef]
 pub struct C.MD_BLOCK_CODE_DETAIL {
 pub:
 	info       C.MD_ATTRIBUTE
@@ -140,23 +147,27 @@ pub:
 	fence_char byte
 }
 
+[typedef]
 pub struct C.MD_BLOCK_TD_DETAIL {
 pub:
 	align MD_ALIGN
 }
 
+[typedef]
 pub struct C.MD_SPAN_A_DETAIL {
 pub:
 	href  C.MD_ATTRIBUTE
 	title C.MD_ATTRIBUTE
 }
 
+[typedef]
 pub struct C.MD_SPAN_IMG_DETAIL {
 pub:
 	src   C.MD_ATTRIBUTE
 	title C.MD_ATTRIBUTE
 }
 
+[typedef]
 pub struct C.MD_SPAN_WIKILINK_DETAIL {
 pub:
 	target C.MD_ATTRIBUTE

--- a/md4c.v
+++ b/md4c.v
@@ -162,7 +162,7 @@ pub:
 	target C.MD_ATTRIBUTE
 }
 
-pub fn C.md_parse(text &char, size u32, parser &C.MD_PARSER, userdata voidptr) int
+fn C.md_parse(text &char, size u32, parser &C.MD_PARSER, userdata voidptr) int
 
 pub fn new(parser_flags u32, enter_block_cb BlockFn, leave_block_cb BlockFn, enter_span_cb SpanFn, leave_span_cb SpanFn, text_cb TextFn, debug_cb DebugFn) C.MD_PARSER {
 	return C.MD_PARSER{
@@ -177,6 +177,6 @@ pub fn new(parser_flags u32, enter_block_cb BlockFn, leave_block_cb BlockFn, ent
 	}
 }
 
-pub fn parse(text &char, size u32, parser &C.MD_PARSER, userdata voidptr) int {
+fn parse(text &char, size u32, parser &C.MD_PARSER, userdata voidptr) int {
 	return C.md_parse(text, size, parser, userdata)
 }

--- a/plaintext.v
+++ b/plaintext.v
@@ -33,36 +33,31 @@ mut:
 	writer strings.Builder = strings.new_builder(200)
 }
 
-fn (mut pt PlaintextRenderer) enter_block(typ MD_BLOCKTYPE, detail voidptr) int {
+fn (mut pt PlaintextRenderer) enter_block(typ MD_BLOCKTYPE, detail voidptr) ? {
 	// TODO Remove, functions can't have two args with name `_`
 	_ = typ
 	_ = detail
-	return 0
 }
 
-fn (mut pt PlaintextRenderer) leave_block(typ MD_BLOCKTYPE, _ voidptr) int {
+fn (mut pt PlaintextRenderer) leave_block(typ MD_BLOCKTYPE, _ voidptr) ? {
 	if typ !in [.md_block_doc, .md_block_hr, .md_block_html] {
 		pt.writer.write_b(`\n`)
 	}
-
-	return 0
 }
 
-fn (mut pt PlaintextRenderer) enter_span(typ MD_SPANTYPE, detail voidptr) int {
+fn (mut pt PlaintextRenderer) enter_span(typ MD_SPANTYPE, detail voidptr) ? {
 	// TODO Remove, functions can't have two args with name `_`
 	_ = typ
 	_ = detail
-	return 0
 }
 
-fn (mut pt PlaintextRenderer) leave_span(typ MD_SPANTYPE, detail voidptr) int {
+fn (mut pt PlaintextRenderer) leave_span(typ MD_SPANTYPE, detail voidptr) ? {
 	// TODO Remove, functions can't have two args with name `_`
 	_ = typ
 	_ = detail
-	return 0
 }
 
-fn (mut pt PlaintextRenderer) text(typ MD_TEXTTYPE, text string) int {
+fn (mut pt PlaintextRenderer) text(typ MD_TEXTTYPE, text string) ? {
 	match typ {
 		.md_text_null_char {}
 		.md_text_html {}
@@ -73,12 +68,9 @@ fn (mut pt PlaintextRenderer) text(typ MD_TEXTTYPE, text string) int {
 			pt.writer.write_string(text)
 		}
 	}
-
-	return 0
 }
 
 fn (mut pt PlaintextRenderer) debug_log(msg string) {
-	// TODO Remove, functions can't have two args with name `_`
 	unsafe { msg.free() }
 }
 

--- a/plaintext.v
+++ b/plaintext.v
@@ -1,5 +1,5 @@
 /*
- * MD4C: Markdown parser for C
+* MD4C: Markdown parser for C
  * (http://github.com/mity/md4c)
  *
  * Copyright (c) 2016-2019 Martin Mitáš
@@ -22,99 +22,70 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
- */
+*/
 
 module markdown
 
 import strings
 
-const (
-	nl = '\n'
-)
-
-struct MdPlaintext {
-	userdata voidptr
-	process_output ProcessFn
+struct PlaintextRenderer {
+mut:
+	writer strings.Builder = strings.new_builder(200)
 }
 
-fn render_output(md &MdPlaintext, text charptr, size u32) {
-	md.process_output(text, size, md.userdata)
-}
-
-fn pt_enter_block_callback(typ MD_BLOCKTYPE, detail voidptr, userdata voidptr) int {
+fn (mut pt PlaintextRenderer) enter_block(typ MD_BLOCKTYPE, detail voidptr) int {
 	// TODO Remove, functions can't have two args with name `_`
 	_ = typ
 	_ = detail
-	_ = userdata
 	return 0
 }
 
-fn pt_leave_block_callback(typ MD_BLOCKTYPE, _ voidptr, userdata voidptr) int {
-	md := &MdPlaintext(userdata)
-
+fn (mut pt PlaintextRenderer) leave_block(typ MD_BLOCKTYPE, _ voidptr) int {
 	if typ !in [.md_block_doc, .md_block_hr, .md_block_html] {
-		render_output(md, charptr(nl.str), u32(nl.len))
+		pt.writer.write_b(`\n`)
 	}
 
 	return 0
 }
 
-fn pt_enter_span_callback(typ MD_SPANTYPE, detail voidptr, userdata voidptr) int {
+fn (mut pt PlaintextRenderer) enter_span(typ MD_SPANTYPE, detail voidptr) int {
 	// TODO Remove, functions can't have two args with name `_`
 	_ = typ
 	_ = detail
-	_ = userdata
 	return 0
 }
 
-fn pt_leave_span_callback(typ MD_SPANTYPE, detail voidptr, userdata voidptr) int {
+fn (mut pt PlaintextRenderer) leave_span(typ MD_SPANTYPE, detail voidptr) int {
 	// TODO Remove, functions can't have two args with name `_`
 	_ = typ
 	_ = detail
-	_ = userdata
 	return 0
 }
 
-fn pt_text_callback(typ MD_TEXTTYPE, text charptr, size u32, userdata voidptr) int {
-	md := &MdPlaintext(userdata)
+fn (mut pt PlaintextRenderer) text(typ MD_TEXTTYPE, text string) int {
 	match typ {
 		.md_text_null_char {}
 		.md_text_html {}
-		.md_text_br,
-		.md_text_softbr { render_output(md, charptr(nl.str), u32(nl.len)) }
-		else { render_output(md, text, size) }
+		.md_text_br, .md_text_softbr {
+			pt.writer.write_b(`\n`)
+		}
+		else {
+			pt.writer.write_string(text)
+		}
 	}
 
 	return 0
 }
 
-fn pt_debug_log_callback(msg charptr, userdata voidptr) {
+fn (mut pt PlaintextRenderer) debug_log(msg string) {
 	// TODO Remove, functions can't have two args with name `_`
-	_ = msg
-	_ = userdata
+	unsafe { msg.free() }
 }
-
-fn md_text(orig_input charptr, input_size u32, process_output ProcessFn, userdata voidptr, parser_flags u32) int {
-	parser := new(
-		parser_flags,
-		pt_enter_block_callback,
-		pt_leave_block_callback,
-		pt_enter_span_callback,
-		pt_leave_span_callback,
-		pt_text_callback,
-		pt_debug_log_callback
-	)
-	mut pt := MdPlaintext{
-		userdata: userdata,
-		process_output: process_output
-	}
-	mut input := unsafe { tos3(orig_input) }
-	return parse(charptr(input.str), input_size, &parser, &pt)
-}
-
 
 pub fn to_plain(input string) string {
-	mut wr := strings.new_builder(200)
-	md_text(charptr(input.str), u32(input.len), write_data_cb, &wr, u32(C.MD_DIALECT_GITHUB))
-	return wr.str().trim_space()
+	mut pt_renderer := PlaintextRenderer{}
+	render(input, mut pt_renderer) or {
+		return ''
+	}
+	return pt_renderer.writer.str().trim_space()
 }

--- a/renderer.v
+++ b/renderer.v
@@ -28,32 +28,55 @@ module markdown
 // Renderer represents an entity that accepts incoming data and renders the content.
 pub interface Renderer {
 mut:
-	enter_block(typ MD_BLOCKTYPE, detail voidptr) int
-	leave_block(typ MD_BLOCKTYPE, detail voidptr) int
-	enter_span(typ MD_SPANTYPE, detail voidptr) int
-	leave_span(typ MD_SPANTYPE, detail voidptr) int
-	text(typ MD_TEXTTYPE, content string) int
+	enter_block(typ MD_BLOCKTYPE, detail voidptr) ?
+	leave_block(typ MD_BLOCKTYPE, detail voidptr) ?
+	enter_span(typ MD_SPANTYPE, detail voidptr) ?
+	leave_span(typ MD_SPANTYPE, detail voidptr) ?
+	text(typ MD_TEXTTYPE, content string) ?
 	debug_log(msg string)
 }
 
+fn renderer_handle_error(err IError) int {
+	if err.code != 0 {
+		return err.code
+	} else {
+		return 1
+	}
+}
+
 fn renderer_enter_block_cb(typ MD_BLOCKTYPE, detail voidptr, mut renderer Renderer) int {
-	return renderer.enter_block(typ, detail)
+	renderer.enter_block(typ, detail) or {
+		return renderer_handle_error(err)
+	}
+	return 0
 }
 
 fn renderer_leave_block_cb(typ MD_BLOCKTYPE, detail voidptr, mut renderer Renderer) int {
-	return renderer.leave_block(typ, detail)
+	renderer.leave_block(typ, detail) or {
+		return renderer_handle_error(err)
+	}
+	return 0
 }
 
 fn renderer_enter_span_cb(typ MD_SPANTYPE, detail voidptr, mut renderer Renderer) int {
-	return renderer.enter_span(typ, detail)
+	renderer.enter_span(typ, detail) or {
+		return renderer_handle_error(err)
+	}
+	return 0
 }
 
 fn renderer_leave_span_cb(typ MD_SPANTYPE, detail voidptr, mut renderer Renderer) int {
-	return renderer.leave_span(typ, detail)
+	renderer.leave_span(typ, detail) or {
+		return renderer_handle_error(err)
+	}
+	return 0
 }
 
 fn renderer_text_cb(typ MD_TEXTTYPE, text &char, size u32, mut renderer Renderer) int {
-	return renderer.text(typ, unsafe { text.vstring_with_len(int(size)) })
+	renderer.text(typ, unsafe { text.vstring_with_len(int(size)) }) or {
+		return renderer_handle_error(err)
+	}
+	return 0
 }
 
 fn renderer_debug_log_cb(msg &char, mut renderer Renderer) {

--- a/renderer.v
+++ b/renderer.v
@@ -1,0 +1,72 @@
+/*
+* MD4C: Markdown parser for C
+ * (http://github.com/mity/md4c)
+ *
+ * Copyright (c) 2016-2019 Martin Mitáš
+ * Copyright (c) 2020 Ned Palacios (V bindings)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+*/
+module markdown
+
+// Renderer represents an entity that accepts incoming data and renders the content.
+pub interface Renderer {
+mut:
+	enter_block(typ MD_BLOCKTYPE, detail voidptr) int
+	leave_block(typ MD_BLOCKTYPE, detail voidptr) int
+	enter_span(typ MD_SPANTYPE, detail voidptr) int
+	leave_span(typ MD_SPANTYPE, detail voidptr) int
+	text(typ MD_TEXTTYPE, content string) int
+	debug_log(msg string)
+}
+
+fn renderer_enter_block_cb(typ MD_BLOCKTYPE, detail voidptr, mut renderer Renderer) int {
+	return renderer.enter_block(typ, detail)
+}
+
+fn renderer_leave_block_cb(typ MD_BLOCKTYPE, detail voidptr, mut renderer Renderer) int {
+	return renderer.leave_block(typ, detail)
+}
+
+fn renderer_enter_span_cb(typ MD_SPANTYPE, detail voidptr, mut renderer Renderer) int {
+	return renderer.enter_span(typ, detail)
+}
+
+fn renderer_leave_span_cb(typ MD_SPANTYPE, detail voidptr, mut renderer Renderer) int {
+	return renderer.leave_span(typ, detail)
+}
+
+fn renderer_text_cb(typ MD_TEXTTYPE, text &char, size u32, mut renderer Renderer) int {
+	return renderer.text(typ, unsafe { text.vstring_with_len(int(size)) })
+}
+
+fn renderer_debug_log_cb(msg &char, mut renderer Renderer) {
+	renderer.debug_log(unsafe { msg.vstring() })
+}
+
+// render parses and renders a given markdown string based on the renderer. 
+pub fn render(src string, mut renderer Renderer) ? {
+	parser := new(u32(C.MD_DIALECT_GITHUB), renderer_enter_block_cb, renderer_leave_block_cb,
+		renderer_enter_span_cb, renderer_leave_span_cb, renderer_text_cb, renderer_debug_log_cb)
+
+	err_code := parse(src.str, u32(src.len), &parser, &renderer)
+	if err_code != 0 {
+		return error_with_code('Something went wrong while parsing.', err_code)
+	}
+}

--- a/renderer_test.v
+++ b/renderer_test.v
@@ -1,0 +1,35 @@
+/*
+* MD4C: Markdown parser for C
+ * (http://github.com/mity/md4c)
+ *
+ * Copyright (c) 2016-2019 Martin Mitáš
+ * Copyright (c) 2020 Ned Palacios (V bindings)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+*/
+
+module markdown
+
+fn test_render() ? {
+	mut pt := PlaintextRenderer{}
+	text := '# Hello World\nhello **bold**'
+	render(text, mut pt) ?
+	out := pt.writer.str()
+	assert out == 'Hello World\nhello bold\n'
+}


### PR DESCRIPTION
This PR adds an interface for implementing custom renderers. With this, you can write your own using the features of V without diving into the semantics of C (not totally, we still have `voidptr`). Prior to this, it is difficult to build a simple renderer without knowing the functions to implement and to connect to the MD4C parser. In order to fully utilize and showcase this interface, the plaintext renderer has been rewritten.

NOTE: This is somewhat related to a specific concern raised in #5:

> Also, IMO it would be better to have a safe interface if V and take a []byte.

Except the `[]byte` part. Not sure if all renderers should be text-based (I'm thinking there should be a renderer for inspecting markdown AST only or markdown to `json2.Any`).