### PR TITLE
Add option `MD_FLAG_HARD_SOFT_BREAKS`

### DIFF
--- a/lib/md4c/md4c.c
+++ b/lib/md4c/md4c.c
@@ -4415,7 +4415,9 @@ md_process_inlines(MD_CTX* ctx, const MD_LINE* lines, int n_lines)
                 MD_TEXTTYPE break_type = MD_TEXT_SOFTBR;
 
                 if(text_type == MD_TEXT_NORMAL) {
-                    if(enforce_hardbreak)
+                    if(ctx->parser.flags & MD_FLAG_HARD_SOFT_BREAKS)
+                        break_type = MD_TEXT_BR;
+                    else if(enforce_hardbreak)
                         break_type = MD_TEXT_BR;
                     else if((CH(line->end) == _T(' ') && CH(line->end+1) == _T(' ')))
                         break_type = MD_TEXT_BR;

--- a/lib/md4c/md4c.h
+++ b/lib/md4c/md4c.h
@@ -316,6 +316,7 @@ typedef struct MD_SPAN_WIKILINK {
 #define MD_FLAG_LATEXMATHSPANS              0x1000  /* Enable $ and $$ containing LaTeX equations. */
 #define MD_FLAG_WIKILINKS                   0x2000  /* Enable wiki links extension. */
 #define MD_FLAG_UNDERLINE                   0x4000  /* Enable underline extension (and disables '_' for normal emphasis). */
+#define MD_FLAG_HARD_SOFT_BREAKS            0x8000  /* Force all soft breaks to act as hard breaks. */
 
 #define MD_FLAG_PERMISSIVEAUTOLINKS         (MD_FLAG_PERMISSIVEEMAILAUTOLINKS | MD_FLAG_PERMISSIVEURLAUTOLINKS | MD_FLAG_PERMISSIVEWWWAUTOLINKS)
 #define MD_FLAG_NOHTML                      (MD_FLAG_NOHTMLBLOCKS | MD_FLAG_NOHTMLSPANS)


### PR DESCRIPTION
Excerpt from https://github.com/mity/md4c/pull/193
> ### [Soft Line Breaks - CommonMark Spec](https://spec.commonmark.org/0.30/#soft-line-breaks)
>
> The ability to treat soft line breaks as hard line breaks is something specified in the spec, and highly needed for my project. Thank you for creating this library.

- Apply changes from the upstream PR to our copy.