### PR TITLE
prevent using __builtin_unreachable when compiling with tcc

### DIFF
--- a/lib/md4c/md4c.c
+++ b/lib/md4c/md4c.c
@@ -90,7 +90,7 @@
 
     #define MD_UNREACHABLE()        MD_ASSERT(1 == 0)
 #else
-    #ifdef __GNUC__
+    #if defined __GNUC__ && !defined __TINYC__
         #define MD_ASSERT(cond)     do { if(!(cond)) __builtin_unreachable(); } while(0)
         #define MD_UNREACHABLE()    do { __builtin_unreachable(); } while(0)
     #elif defined _MSC_VER  &&  _MSC_VER > 120


### PR DESCRIPTION
This change improves the conditional compile logic around the decision to use __builtin_unreachable or not.