### PR TITLE
make custom renderer rendering easier

### DIFF
--- a/plaintext.v
+++ b/plaintext.v
@@ -34,6 +34,10 @@ mut:
 	writer strings.Builder = strings.new_builder(200)
 }
 
+fn (mut pt PlaintextRenderer) str() string {
+	return pt.writer.str()
+}
+
 fn (mut pt PlaintextRenderer) enter_block(typ MD_BLOCKTYPE, detail voidptr) ? {
 	// TODO Remove, functions can't have two args with name `_`
 	_ = typ
@@ -77,6 +81,6 @@ fn (mut pt PlaintextRenderer) debug_log(msg string) {
 
 pub fn to_plain(input string) string {
 	mut pt_renderer := PlaintextRenderer{}
-	render(input, mut pt_renderer) or { return '' }
-	return pt_renderer.writer.str().trim_space()
+	out := render(input, mut pt_renderer) or { '' }
+	return out
 }

--- a/renderer.v
+++ b/renderer.v
@@ -29,6 +29,7 @@ module markdown
 // Renderer represents an entity that accepts incoming data and renders the content.
 pub interface Renderer {
 mut:
+	str() string
 	enter_block(typ MD_BLOCKTYPE, detail voidptr) ?
 	leave_block(typ MD_BLOCKTYPE, detail voidptr) ?
 	enter_span(typ MD_SPANTYPE, detail voidptr) ?
@@ -77,7 +78,7 @@ fn renderer_debug_log_cb(msg &char, mut renderer Renderer) {
 }
 
 // render parses and renders a given markdown string based on the renderer.
-pub fn render(src string, mut renderer Renderer) ! {
+pub fn render(src string, mut renderer Renderer) !string {
 	parser := new(u32(C.MD_DIALECT_GITHUB), renderer_enter_block_cb, renderer_leave_block_cb,
 		renderer_enter_span_cb, renderer_leave_span_cb, renderer_text_cb, renderer_debug_log_cb)
 
@@ -85,4 +86,6 @@ pub fn render(src string, mut renderer Renderer) ! {
 	if err_code != 0 {
 		return error_with_code('Something went wrong while parsing.', err_code)
 	}
+
+	return renderer.str().trim_space()
 }

--- a/renderer_test.v
+++ b/renderer_test.v
@@ -27,10 +27,10 @@
 
 module markdown
 
-fn test_render() {
+fn test_render() ! {
 	mut pt := PlaintextRenderer{}
 	text := '# Hello World\nhello **bold**'
-	render(text, mut pt)!
-	out := pt.writer.str()
+	out := render(text, mut pt)!
+	assert out.len != 0
 	assert out == 'Hello World\nhello bold\n'
 }


### PR DESCRIPTION
This PR modifies the way custom renderers render content by having the `render` function return `!string` and at the same time add a new interface method to `Renderer` which is `str()`.

Previously, in order to render content from a custom renderer to `render`, you need to expose the `writer` of your render to the public as the `render` does not return a value at all which should not be an expected behavior. (Sidenote: I know I wrote this but now that I actually used it, I would like to punch my past self for doing this lol)