### PR TITLE
fix fn call arg u32 as int

### DIFF
--- a/src/html_experimental.v
+++ b/src/html_experimental.v
@@ -64,7 +64,7 @@ fn tos_attribute(attr &C.MD_ATTRIBUTE, mut wr strings.Builder) {
 		typ := unsafe { MD_TEXTTYPE(attr.substr_types[i]) }
 		off := unsafe { attr.substr_offsets[i] }
 		size := unsafe { attr.substr_offsets[i + 1] - off }
-		text := unsafe { (attr.text + off).vstring_with_len(size) }
+		text := unsafe { (attr.text + off).vstring_with_len(int(size)) }
 
 		match typ {
 			.md_text_null_char {


### PR DESCRIPTION
This PR fix fn call arg u32 as int.